### PR TITLE
Remove the Suspense boundary for individual items

### DIFF
--- a/components/meta.js
+++ b/components/meta.js
@@ -86,7 +86,7 @@ export default function Meta() {
         text-decoration: underline;
       }
       .item-skeleton {
-        margin: 8px 0;
+        margin: 5px 0;
         overflow: hidden;
       }
       .item-skeleton:before, .item-skeleton:after {
@@ -96,7 +96,7 @@ export default function Meta() {
         max-width: 100%;
         height: 16px;
         background: #eee;
-        margin: 2px 0 6px;
+        margin: 6px 0 2px;
         background-image: linear-gradient(270deg, #ccc, #eee, #eee, #ccc);
         background-size: 400% 100%;
         animation: highlight-rotating 8s ease infinite;

--- a/components/meta.js
+++ b/components/meta.js
@@ -1,12 +1,12 @@
-import Head from "next/head";
+import Head from 'next/head'
 // import Router from 'next/router'
 
 export default function Meta() {
   return (
     <div>
       <Head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta charSet="utf-8" />
+        <meta name='viewport' content='width=device-width, initial-scale=1' />
+        <meta charSet='utf-8' />
         {/* <link rel="shortcut icon" href="/static/favicon.ico" /> */}
       </Head>
       <style
@@ -85,9 +85,38 @@ export default function Meta() {
       .meta a:hover {
         text-decoration: underline;
       }
+      .item-skeleton {
+        margin: 8px 0;
+        overflow: hidden;
+      }
+      .item-skeleton:before, .item-skeleton:after {
+        content: '';
+        display: block;
+        width: 350px;
+        max-width: 100%;
+        height: 16px;
+        background: #eee;
+        margin: 2px 0 6px;
+        background-image: linear-gradient(270deg, #ccc, #eee, #eee, #ccc);
+        background-size: 400% 100%;
+        animation: highlight-rotating 8s ease infinite;
+      }
+      .item-skeleton:after {
+        width: 250px;
+        height: 10px;
+        margin: 5px 0;
+      }
+      @keyframes highlight-rotating {
+        from {
+          background-position: 200% 0;
+        }
+        to {
+          background-position: -200% 0;
+        }
+      }
     `,
         }}
       />
     </div>
-  );
+  )
 }

--- a/components/skeletons.js
+++ b/components/skeletons.js
@@ -1,0 +1,19 @@
+export default function Skeletons() {
+  return (
+    <div>
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+      <Skeleton />
+    </div>
+  )
+}
+
+function Skeleton() {
+  return <div className='item-skeleton' />
+}

--- a/components/skeletons.js
+++ b/components/skeletons.js
@@ -1,15 +1,12 @@
 export default function Skeletons() {
+  // Generating 30 skeletons to match the size of the list.
   return (
     <div>
-      <Skeleton />
-      <Skeleton />
-      <Skeleton />
-      <Skeleton />
-      <Skeleton />
-      <Skeleton />
-      <Skeleton />
-      <Skeleton />
-      <Skeleton />
+      {Array(30)
+        .fill(0)
+        .map((_, index) => (
+          <Skeleton key={index} />
+        ))}
     </div>
   )
 }

--- a/pages/rsc.server.js
+++ b/pages/rsc.server.js
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 
 // Shared Components
-import Spinner from '../components/spinner'
+import Skeletons from '../components/skeletons'
 
 // Server Components
 import SystemInfo from '../components/server-info.server'
@@ -35,7 +35,7 @@ function NewsWithData() {
 export default function News() {
   return (
     <Page>
-      <Suspense fallback={<Spinner />}>
+      <Suspense fallback={<Skeletons />}>
         <NewsWithData />
       </Suspense>
       <Footer />

--- a/pages/rsc.server.js
+++ b/pages/rsc.server.js
@@ -26,11 +26,7 @@ function NewsWithData() {
   return (
     <>
       {storyIds.slice(0, 30).map((id) => {
-        return (
-          <Suspense fallback={<Spinner />} key={id}>
-            <StoryWithData id={id} />
-          </Suspense>
-        )
+        return <StoryWithData id={id} key={id} />
       })}
     </>
   )


### PR DESCRIPTION
As mentioned in https://github.com/vercel/next-rsc-demo/issues/13#issuecomment-988319153, we think removing the spinners for individual items will reduce layout shift and improve the overall experience of this app.