### PR TITLE
remove reactRoot option, let nextjs auto-detect react 18

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   experimental: {
-    reactRoot: true,
-    serverComponents: true,
     runtime: 'edge',
+    serverComponents: true,
   },
 }


### PR DESCRIPTION
Since nextjs can auto detect react 18 and opt-in react root rendering and also to align with the doc, remove the option